### PR TITLE
M30 Virtual Gamepad and other minor tweaks. (#1509)

### DIFF
--- a/Cores/Genesis-Plus-GX/PVGenesis/Genesis/PVGenesisEmulatorCore.m
+++ b/Cores/Genesis-Plus-GX/PVGenesis/Genesis/PVGenesisEmulatorCore.m
@@ -727,13 +727,13 @@ static bool environment_callback(unsigned cmd, void *data)
             if (PVSettingsModel.shared.use8BitdoM30) // Maps the Sega Controls to the 8BitDo M30 if enabled in Settings / Controller
             {switch (buttonID) {
                 case PVGenesisButtonUp:
-                    return [[[gamepad leftThumbstick] up] value] > 0.5;
+                    return [[[gamepad leftThumbstick] up] value] > 0.1;
                 case PVGenesisButtonDown:
-                    return [[[gamepad leftThumbstick] down] value] > 0.5;
+                    return [[[gamepad leftThumbstick] down] value] > 0.1;
                 case PVGenesisButtonLeft:
-                    return [[[gamepad leftThumbstick] left] value] > 0.5;
+                    return [[[gamepad leftThumbstick] left] value] > 0.1;
                 case PVGenesisButtonRight:
-                    return [[[gamepad leftThumbstick] right] value] > 0.5;
+                    return [[[gamepad leftThumbstick] right] value] > 0.1;
                 case PVGenesisButtonA:
                     return [[gamepad buttonA] isPressed];
                 case PVGenesisButtonB:

--- a/Cores/PicoDrive/PicodriveGameCore.m
+++ b/Cores/PicoDrive/PicodriveGameCore.m
@@ -558,13 +558,13 @@ static void writeSaveFile(const char* path, int type)
         if (PVSettingsModel.shared.use8BitdoM30) // Maps the Sega Controls to the 8BitDo M30 if enabled in Settings / Controller
         { switch (buttonID) {
             case PVSega32XButtonUp:
-                return [[[gamepad leftThumbstick] up] value] > 0.5;
+                return [[[gamepad leftThumbstick] up] value] > 0.1;
             case PVSega32XButtonDown:
-                return [[[gamepad leftThumbstick] down] value] > 0.5;
+                return [[[gamepad leftThumbstick] down] value] > 0.1;
             case PVSega32XButtonLeft:
-                return [[[gamepad leftThumbstick] left] value] > 0.5;
+                return [[[gamepad leftThumbstick] left] value] > 0.1;
             case PVSega32XButtonRight:
-                return [[[gamepad leftThumbstick] right] value] > 0.5;
+                return [[[gamepad leftThumbstick] right] value] > 0.1;
             case PVSega32XButtonA:
                 return [[gamepad buttonA] isPressed];
             case PVSega32XButtonB:

--- a/Provenance.xcworkspace/xcshareddata/xcschemes/Provenance-Release.xcscheme
+++ b/Provenance.xcworkspace/xcshareddata/xcschemes/Provenance-Release.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1230"
-   version = "1.3">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -100,6 +100,12 @@
             ReferencedContainer = "container:Provenance.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-_UIConstraintBasedLayoutLogUnsatisfiable NO"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Provenance.xcworkspace/xcshareddata/xcschemes/ProvenanceTV-Release.xcscheme
+++ b/Provenance.xcworkspace/xcshareddata/xcschemes/ProvenanceTV-Release.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1230"
-   version = "1.3">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -66,6 +66,12 @@
             ReferencedContainer = "container:Provenance.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-_UIConstraintBasedLayoutLogUnsatisfiable NO"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "ALWAYS_ON_WEBDAV"

--- a/ProvenanceTV/Story Boards/Provenance.storyboard
+++ b/ProvenanceTV/Story Boards/Provenance.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="16097.2" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="0zH-nB-KZk">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="16097.3" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="0zH-nB-KZk">
     <device id="appleTV" appearance="dark"/>
     <dependencies>
         <deployment identifier="tvOS"/>
@@ -371,9 +371,6 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.10980392160000001" green="0.51372549020000002" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="barTintColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="boolean" keyPath="ignoresInvertColors" value="YES"/>
-                        </userDefinedRuntimeAttributes>
                     </tabBar>
                     <connections>
                         <segue destination="7Iz-AI-QKl" kind="relationship" relationship="viewControllers" id="Yra-to-P3B"/>
@@ -396,9 +393,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="mdF-sV-x43"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="boolean" keyPath="ignoresInvertColors" value="YES"/>
-                        </userDefinedRuntimeAttributes>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="YeI-bH-0RW">
@@ -443,11 +437,11 @@
                             <rect key="frame" x="106" y="140" width="118" height="66"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5lv-A6-HuR" id="y0R-gN-gry">
-                                <rect key="frame" x="0.0" y="0.0" width="78" height="66"/>
+                                <rect key="frame" x="0.0" y="0.0" width="90" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
                                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dFB-G1-4da">
-                                        <rect key="frame" x="20" y="0.0" width="38" height="66"/>
+                                        <rect key="frame" x="20" y="0.0" width="50" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="38"/>
                                         <nil key="textColor"/>


### PR DESCRIPTION
* Minimize virtual travel needed to register dpad on M30.

* Set ignoresInvertColors to default on tvOS
Fixes start-up log error message.

* Stop the layoutConstraint Spam for Release on tvOS.

* Stop the layoutConstraint Spam for Release on 